### PR TITLE
cacert.pem CA bundle: update to 2024-02-14

### DIFF
--- a/packages/security/openssl/cert/cacert.pem
+++ b/packages/security/openssl/cert/cacert.pem
@@ -1,7 +1,7 @@
 ##
 ## Bundle of CA Root Certificates
 ##
-## Certificate data from Mozilla as of: Fri Feb  2 10:50:50 2024 GMT
+## Certificate data from Mozilla as of: Tue Feb 20 12:24:43 2024 GMT
 ##
 ## This is a bundle of X.509 certificates of public Certificate Authorities
 ## (CA). These were automatically extracted from Mozilla's root certificates
@@ -14,7 +14,7 @@
 ## Just configure this file as the SSLCACertificateFile.
 ##
 ## Conversion done with mk-ca-bundle.pl version 1.29.
-## SHA256: d3604c12ac560fd4e3f5effda37095b23c0b129f016ef23c0c5c5f1725099b70
+## SHA256: 4d96bd539f4719e9ace493757afbe4a23ee8579de1c97fbebc50bba3c12e8c1e
 ##
 
 


### PR DESCRIPTION
This pull-request was auto-generated by the [update-cacert-pem-certificate-bundle][1] GitHub action workflow.

[1]: https://github.com/heitbaum/actions/blob/e1ec07a34c92eb21661903a563d8223f358f636b/.github/workflows/update-cacert-pem-certificate-bundle.yml