### PR TITLE
cacert.pem CA bundle: update to 2024-06-07

### DIFF
--- a/packages/security/openssl/cert/cacert.pem
+++ b/packages/security/openssl/cert/cacert.pem
@@ -1,7 +1,7 @@
 ##
 ## Bundle of CA Root Certificates
 ##
-## Certificate data from Mozilla as of: Sat Jun  1 11:30:51 2024 GMT
+## Certificate data from Mozilla as of: Thu Jun 13 11:30:48 2024 GMT
 ##
 ## This is a bundle of X.509 certificates of public Certificate Authorities
 ## (CA). These were automatically extracted from Mozilla's root certificates
@@ -14,7 +14,7 @@
 ## Just configure this file as the SSLCACertificateFile.
 ##
 ## Conversion done with mk-ca-bundle.pl version 1.29.
-## SHA256: 4a3ec019bd7e9e943f3f8aaced1545f54b36122a5e1de6f62b24a21b0b53a30e
+## SHA256: 4c03e07a655964bc3f758fd6b3fb36f5ea960ddc234521350e99c9408579924b
 ##
 
 


### PR DESCRIPTION
This pull-request was auto-generated by the [update-cacert-pem-certificate-bundle][1] GitHub action workflow.

[1]: https://github.com/heitbaum/actions/blob/efb255a5bd031a5613679ae75506542cfbf89772/.github/workflows/update-cacert-pem-certificate-bundle.yml