### PR TITLE
cacert.pem CA bundle: update to 2026-02-11

### DIFF
--- a/packages/security/openssl/cert/cacert.pem
+++ b/packages/security/openssl/cert/cacert.pem
@@ -1,7 +1,7 @@
 ##
 ## Bundle of CA Root Certificates
 ##
-## Certificate data from Mozilla as of: Wed Feb  4 11:55:53 2026 GMT
+## Certificate data from Mozilla as of: Mon Feb 16 12:00:02 2026 GMT
 ##
 ## Find updated versions here: https://curl.se/docs/caextract.html
 ##
@@ -15,8 +15,8 @@
 ## an Apache+mod_ssl webserver for SSL client authentication.
 ## Just configure this file as the SSLCACertificateFile.
 ##
-## Conversion done with mk-ca-bundle.pl version 1.30.
-## SHA256: bcff220bf6b97713d6e43da0b6958899376b3f88a9106dfccec8c3f3713e4a58
+## Conversion done with mk-ca-bundle.pl version 1.31.
+## SHA256: 3b98d4e3ff57a326d9587c33633039c8c3a9cf0b55f7ca581d7598ff329eb1f3
 ##
 
 
@@ -3480,8 +3480,8 @@ SM49BAMDA2kAMGYCMQCpKjAd0MKfkFFRQD6VVCHNFmb3U2wIFjnQEnx/Yxvf4zgAOdktUyBFCxxg
 ZzFDJe0CMQCSia7pXGKDYmH5LVerVrkR3SW+ak5KGoJr3M/TvEqzPNcum9v4KGm8ay3sMaE641c=
 -----END CERTIFICATE-----
 
- OISTE Server Root RSA G1
-=========================
+OISTE Server Root RSA G1
+========================
 -----BEGIN CERTIFICATE-----
 MIIFgzCCA2ugAwIBAgIQVaXZZ5Qoxu0M+ifdWwFNGDANBgkqhkiG9w0BAQwFADBLMQswCQYDVQQG
 EwJDSDEZMBcGA1UECgwQT0lTVEUgRm91bmRhdGlvbjEhMB8GA1UEAwwYT0lTVEUgU2VydmVyIFJv


### PR DESCRIPTION
This pull-request was auto-generated by the [update-cacert-pem-certificate-bundle][1] GitHub action workflow.

[1]: https://github.com/heitbaum/actions/blob/b24e69c373e2c0f1e5c47226eef8236535c42344/.github/workflows/update-cacert-pem-certificate-bundle.yml